### PR TITLE
Add @isomorphic-git's hypergit repo (yay experiments!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ With hypergit, each project participant has their own hypergit repo. There is no
 "origin" central authority.
 
 - @noffle: `hypergit://207dbaef657d688ad528573ae66b5a0bede40fcb82e6b91afc44ddd43c84874f`
+- [@isomorphic-git](https://github.com/isomorphic-git): `hypergit://5701a1c08ae15dba17e181b1a9a28bdfb8b95200d77a25be6051bb018e25439a`
 
 If you'd like your hypergit added, open a PR.
 


### PR DESCRIPTION
I'm going to try creating a single repo for the @isomorphic-git project, and namespace the branches by the Github repo name. E.g.
```
> git ls-remote hyper
67f0c3fd63d6c056d858233e188896079083b1b4        refs/heads/isomorphic-git/master
d91f9ac55d3a41f765f6e3e2f13970995c4f2b1e        refs/heads/isomorphic-git.github.io/source
```