### PR TITLE
hypergit service [ install | remove | seed ]

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,7 +4,8 @@ var through = require('through2')
 var fs = require('fs')
 var path = require('path')
 var args = require('minimist')(process.argv)
-const service = require('os-service')
+var service = require('os-service')
+var console2file = require('console2file').default
 var hyperdb = require('hyperdb')
 var spawn = require('child_process').spawnSync
 var discovery = require('discovery-swarm')
@@ -21,6 +22,9 @@ if (args._.length === 2) {
 }
 
 switch (args._[2]) {
+  case 'where':
+    console.log(envpaths.config)
+    break
   case 'create':
     getHyperdb(null, function (err, db) {
       var name = 'swarm'
@@ -40,6 +44,10 @@ switch (args._[2]) {
     }
     break
   case 'seed':
+    console2file({
+      filePath: path.join(envpaths.config, 'log.txt'),
+      fileOnly: false
+    })
     service.run(() => service.stop())
     // seed ALL repos
     getAllHyperdbs(function (err, dbs) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -44,7 +44,9 @@ switch (args._[2]) {
     }
     break
   case 'seed':
-    fs.unlinkSync(path.join(envpaths.config, 'log.txt'))
+    try {
+      fs.unlinkSync(path.join(envpaths.config, 'log.txt'))
+    } catch (err) {}
     console2file({
       filePath: path.join(envpaths.config, 'log.txt'),
       fileOnly: false

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,20 +8,22 @@ var web = require('../src/commands/web')
 var id = require('../src/commands/id')
 var fork = require('../src/commands/fork')
 var service = require('../src/commands/service')
+var utils = require('../src/utils')
 
 if (args._.length === 2) {
-  printUsage()
+  utils.printUsage()
   return
 }
 
 switch (args._[2]) {
-  case 'where':
-    console.log(envpaths.config)
-    break
   case 'create':
     create()
     break
   case 'service':
+    if (args._.length === 3) {
+      utils.printUsage()
+      return
+    }
     service(args._[3])
     break
   case 'seed':
@@ -37,12 +39,7 @@ switch (args._[2]) {
     fork()
     break
   default:
-    printUsage()
+    utils.printUsage()
     break
 }
 
-function printUsage () {
-  require('fs')
-    .createReadStream(path.join(__dirname, '/usage.txt'))
-    .pipe(process.stdout)
-}

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -44,6 +44,7 @@ switch (args._[2]) {
     }
     break
   case 'seed':
+    fs.unlinkSync(path.join(envpaths.config, 'log.txt'))
     console2file({
       filePath: path.join(envpaths.config, 'log.txt'),
       fileOnly: false

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,6 +4,7 @@ var through = require('through2')
 var fs = require('fs')
 var path = require('path')
 var args = require('minimist')(process.argv)
+const service = require('os-service')
 var hyperdb = require('hyperdb')
 var spawn = require('child_process').spawnSync
 var discovery = require('discovery-swarm')
@@ -28,7 +29,18 @@ switch (args._[2]) {
       console.log('hypergit://' + key)
     })
     break
+  case 'service':
+    switch (args._[3]) {
+      case 'install':
+        service.add("hypergit", { programArgs: ["seed"] }, (error) => error ? console.log(error) : console.log('installed'))
+        break
+      case 'remove':
+        service.remove("hypergit", (error) => error ? console.log(error) : console.log('removed'))
+        break
+    }
+    break
   case 'seed':
+    service.run(() => service.stop())
     // seed ALL repos
     getAllHyperdbs(function (err, dbs) {
       dbs.forEach(function (db, n) {

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -8,3 +8,10 @@ Commands:
   fork          Create a new remote 'fork' of the current repo.
 
   web           Host local web frontend.
+
+  service install      Install an OS service that starts the seeder on boot
+
+  service remove       Uninstall the OS service that starts the seeder on boot
+
+  service logdir       Print out the directory where the log file are saved
+

--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
     "hypercore": "^6.15.0",
     "hyperdb": "^3.1.2",
     "hyperdb-git-repo": "^1.0.2",
+    "is-elevated": "^2.0.1",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "os-service": "^2.1.3",
+    "sudo-prompt": "^8.2.0",
     "through2": "^2.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "keywords": [],
   "dependencies": {
+    "console2file": "^1.1.5",
     "dat-swarm-defaults": "^1.0.1",
     "discovery-swarm": "^5.1.1",
     "env-paths": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "hyperdb-git-repo": "^1.0.2",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
+    "os-service": "^2.1.3",
     "through2": "^2.0.3"
   },
   "devDependencies": {

--- a/src/commands/service.js
+++ b/src/commands/service.js
@@ -1,8 +1,13 @@
+var fs = require('fs')
+var path = require('path')
 var console2file = require('console2file').default
 var os_service = require('os-service')
 var sudo = require('sudo-prompt')
 var isElevated = require('is-elevated')
 var seed = require('./seed')
+var utils = require('../utils')
+
+var envpaths = utils.envpaths
 
 function logresult (status) {
   return function (error) {
@@ -53,12 +58,20 @@ module.exports = function service (command) {
       fs.unlink(path.join(envpaths.config, 'log.txt'), () => {
         console2file({
           filePath: path.join(envpaths.config, 'log.txt'),
+          timestamp: true,
           fileOnly: false
         })
+        console.log('Running with CLI arguments: ' + formatArgvString(process.argv))
         os_service.run(() => os_service.stop())
         // seed ALL repos
         seed()
       })
+      break
+    case 'logdir':
+      console.log(envpaths.config)
+      break
+    default:
+      utils.printUsage()
       break
   }
 }

--- a/src/commands/service.js
+++ b/src/commands/service.js
@@ -1,5 +1,7 @@
-var service = require('os-service')
 var console2file = require('console2file').default
+var os_service = require('os-service')
+var sudo = require('sudo-prompt')
+var isElevated = require('is-elevated')
 var seed = require('./seed')
 
 function logresult (status) {
@@ -12,13 +14,40 @@ function logresult (status) {
   }
 }
 
+function logoutput (err, stdout, stderr) {
+  if (err) {
+    console.log(err)
+  } else {
+    if (stderr) {
+      console.log(stderr)
+    }
+    console.log(stdout)
+  }
+}
+
+function formatArgvString (argv) {
+  return argv.map(x => `"${x}"`).join(' ')
+}
+
 module.exports = function service (command) {
   switch (command) {
     case 'install':
-      service.add("hypergit", { programArgs: ["service", "seed"] }, logresult('installed'))
+      isElevated().then(function (elevated) {
+        if (elevated) {
+          os_service.add("hypergit", { programArgs: ["service", "seed"] }, logresult('installed'))
+        } else {
+          sudo.exec(formatArgvString(process.argv), {name: 'hypergit CLI'}, logoutput)
+        }
+      })
       break
     case 'remove':
-      service.remove("hypergit", logresult('removed'))
+      isElevated().then(function (elevated) {
+        if (elevated) {
+          os_service.remove("hypergit", logresult('removed'))
+        } else {
+          sudo.exec(formatArgvString(process.argv), {name: 'hypergit CLI'}, logoutput)
+        }
+      })
       break
     case 'seed':
       fs.unlink(path.join(envpaths.config, 'log.txt'), () => {
@@ -26,7 +55,7 @@ module.exports = function service (command) {
           filePath: path.join(envpaths.config, 'log.txt'),
           fileOnly: false
         })
-        service.run(() => service.stop())
+        os_service.run(() => os_service.stop())
         // seed ALL repos
         seed()
       })

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,14 @@ var spawn = require('child_process').spawnSync;
 var envpaths = require('env-paths')('hypergit')
 var gitconfig = require('gitconfiglocal')
 
+exports.envpaths = envpaths
+
+exports.printUsage = function printUsage () {
+  require('fs')
+    .createReadStream(path.join(__dirname, '..', 'bin/usage.txt'))
+    .pipe(process.stdout)
+}
+
 exports.createRemote = function createRemote (name, url) {
   spawn('git', ['remote', 'add', name, url]);
 }


### PR DESCRIPTION
npm is awesome. It was like barely any code.

`hypergit service install` - will elevate privileges using [sudo-prompt](https://npm.im/sudo-prompt) and create a service using [os-service](https://npm.im/os-service)

`hypergit service remove` - will undo what `hypergit service install` did

`hypergit service seed` - is what the OS service calls. Basically a thin wrapper around regular `hypergit seed` that redirects stdout to a log file and enables the OS to gracefully stop it.

`hypergit service logdir` - will print out the envpaths.config because I can never remember where the log is saved.

The last trick is to go into the Window Services settings and modify the `hypergit` service to run as the current user rather than the Local System, so that `envpaths` will be for your local user account rather than root. I didn't see a way to do that programmatically without knowing the current user's password, so I've left that for possible future work. I imagine something similar must be done for Mac/Linux users.

Let's discuss! Is this good enough to merge? Is it an abomination that should be shunned? Does it work on anyone else's computer? Am I seeding all the repos correctly?